### PR TITLE
Prepended issue- to repository name

### DIFF
--- a/src/sumaxy.zsh
+++ b/src/sumaxy.zsh
@@ -158,9 +158,9 @@ function format-output # {{{
   local pn rn ru mode=${1-}
   while read pn rn ru; do
     case $mode in
-    ar) o print "zypper ar -cgkn $rn $ru $rn" ;;
-    rr) o print "zypper rr $ru" ;;
-    * ) o print "$rn $ru" ;;
+    ar) o print "zypper ar -cgkn issue-$rn $ru issue-$rn" ;;
+    rr) o print "zypper rr issue-$ru" ;;
+    * ) o print "issue-$rn $ru" ;;
     esac
     done
 } # }}}

--- a/tests/100-happy-path.t
+++ b/tests/100-happy-path.t
@@ -11,87 +11,87 @@ setup::
 arch only::
 
   $ sumaxy $wd i586
-  sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_i586/
-  sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_i586/
-  sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_i586/
-  sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_i586/
-  sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_i586/
-  sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_i586/
-  sles-for-vmware:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLES4VMWARE_11-SP3_i586/
+  issue-sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_i586/
+  issue-sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_i586/
+  issue-sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_i586/
+  issue-sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_i586/
+  issue-sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_i586/
+  issue-sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_i586/
+  issue-sles-for-vmware:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLES4VMWARE_11-SP3_i586/
 
   $ sumaxy $wd ia64
-  sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_ia64/
-  sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_ia64/
-  sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_ia64/
-  sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_ia64/
+  issue-sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_ia64/
+  issue-sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_ia64/
+  issue-sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_ia64/
+  issue-sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_ia64/
 
   $ sumaxy $wd ppc64
-  sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_ppc64/
-  sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_ppc64/
-  sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_ppc64/
-  sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_ppc64/
+  issue-sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_ppc64/
+  issue-sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_ppc64/
+  issue-sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_ppc64/
+  issue-sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_ppc64/
 
   $ sumaxy $wd s390x
-  sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_s390x/
-  sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_s390x/
-  sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_s390x/
-  sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_s390x/
+  issue-sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_s390x/
+  issue-sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_s390x/
+  issue-sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_s390x/
+  issue-sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_s390x/
 
   $ sumaxy $wd x86_64
-  sle-debuginfo:11.1-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP1-TERADATA_x86_64/
-  sle-debuginfo:11.3-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3-TERADATA_x86_64/
-  sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_x86_64/
-  sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_x86_64/
-  sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/
-  sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/
-  sles:11.1-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP1-TERADATA_x86_64/
-  sles:11.3-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3-TERADATA_x86_64/
-  sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_x86_64/
-  sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_x86_64/
-  sles-for-vmware:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLES4VMWARE_11-SP3_x86_64/
+  issue-sle-debuginfo:11.1-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP1-TERADATA_x86_64/
+  issue-sle-debuginfo:11.3-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3-TERADATA_x86_64/
+  issue-sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_x86_64/
+  issue-sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_x86_64/
+  issue-sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/
+  issue-sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/
+  issue-sles:11.1-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP1-TERADATA_x86_64/
+  issue-sles:11.3-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3-TERADATA_x86_64/
+  issue-sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_x86_64/
+  issue-sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_x86_64/
+  issue-sles-for-vmware:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLES4VMWARE_11-SP3_x86_64/
 
 arch + products::
 
   $ sumaxy $wd x86_64 sled
-  sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/
-  sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/
+  issue-sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/
+  issue-sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/
 
   $ sumaxy $wd x86_64 sled:11.3 sled:11.4
-  sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/
-  sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/
+  issue-sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/
+  issue-sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/
 
   $ sumaxy $wd x86_64 sled:11.2
 
   $ sumaxy $wd x86_64 sled:11.3
-  sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/
+  issue-sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/
 
   $ sumaxy $wd x86_64 sled:11.4
-  sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/
+  issue-sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/
 
   $ sumaxy $wd x86_64 sled:11.\?
-  sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/
-  sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/
+  issue-sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/
+  issue-sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/
 
   $ sumaxy $wd x86_64 SLED
-  sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/
-  sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/
+  issue-sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/
+  issue-sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/
 
   $ sumaxy $wd i586 SUSE_SLED
-  sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_i586/
-  sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_i586/
+  issue-sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_i586/
+  issue-sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_i586/
 
   $ sumaxy $wd ppc64 SLES
-  sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_ppc64/
-  sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_ppc64/
+  issue-sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_ppc64/
+  issue-sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_ppc64/
 
   $ sumaxy $wd x86_64 SUSE_SLES
-  sles:11.1-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP1-TERADATA_x86_64/
-  sles:11.3-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3-TERADATA_x86_64/
-  sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_x86_64/
-  sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_x86_64/
+  issue-sles:11.1-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP1-TERADATA_x86_64/
+  issue-sles:11.3-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3-TERADATA_x86_64/
+  issue-sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_x86_64/
+  issue-sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_x86_64/
 
   $ sumaxy $wd x86_64 SUSE_SLES:11-SP4
-  sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_x86_64/
+  issue-sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_x86_64/
 
   $ sumaxy $wd x86_64 SUSE_SLED:11-sp4
-  sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/
+  issue-sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/

--- a/tests/200-happy-path,addrepo.t
+++ b/tests/200-happy-path,addrepo.t
@@ -11,59 +11,59 @@ setup::
 arch only::
 
   $ sumaxy -A $wd i586
-  zypper ar -cgkn sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_i586/ sle-debuginfo:11.3::p=1023
-  zypper ar -cgkn sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_i586/ sle-debuginfo:11.4::p=1023
-  zypper ar -cgkn sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_i586/ sled:11.3::p=1023
-  zypper ar -cgkn sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_i586/ sled:11.4::p=1023
-  zypper ar -cgkn sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_i586/ sles:11.3::p=1023
-  zypper ar -cgkn sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_i586/ sles:11.4::p=1023
-  zypper ar -cgkn sles-for-vmware:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLES4VMWARE_11-SP3_i586/ sles-for-vmware:11.3::p=1023
+  zypper ar -cgkn issue-sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_i586/ issue-sle-debuginfo:11.3::p=1023
+  zypper ar -cgkn issue-sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_i586/ issue-sle-debuginfo:11.4::p=1023
+  zypper ar -cgkn issue-sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_i586/ issue-sled:11.3::p=1023
+  zypper ar -cgkn issue-sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_i586/ issue-sled:11.4::p=1023
+  zypper ar -cgkn issue-sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_i586/ issue-sles:11.3::p=1023
+  zypper ar -cgkn issue-sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_i586/ issue-sles:11.4::p=1023
+  zypper ar -cgkn issue-sles-for-vmware:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLES4VMWARE_11-SP3_i586/ issue-sles-for-vmware:11.3::p=1023
 
   $ sumaxy -A $wd ia64
-  zypper ar -cgkn sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_ia64/ sle-debuginfo:11.3::p=1023
-  zypper ar -cgkn sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_ia64/ sle-debuginfo:11.4::p=1023
-  zypper ar -cgkn sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_ia64/ sles:11.3::p=1023
-  zypper ar -cgkn sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_ia64/ sles:11.4::p=1023
+  zypper ar -cgkn issue-sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_ia64/ issue-sle-debuginfo:11.3::p=1023
+  zypper ar -cgkn issue-sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_ia64/ issue-sle-debuginfo:11.4::p=1023
+  zypper ar -cgkn issue-sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_ia64/ issue-sles:11.3::p=1023
+  zypper ar -cgkn issue-sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_ia64/ issue-sles:11.4::p=1023
 
   $ sumaxy -A $wd ppc64
-  zypper ar -cgkn sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_ppc64/ sle-debuginfo:11.3::p=1023
-  zypper ar -cgkn sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_ppc64/ sle-debuginfo:11.4::p=1023
-  zypper ar -cgkn sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_ppc64/ sles:11.3::p=1023
-  zypper ar -cgkn sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_ppc64/ sles:11.4::p=1023
+  zypper ar -cgkn issue-sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_ppc64/ issue-sle-debuginfo:11.3::p=1023
+  zypper ar -cgkn issue-sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_ppc64/ issue-sle-debuginfo:11.4::p=1023
+  zypper ar -cgkn issue-sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_ppc64/ issue-sles:11.3::p=1023
+  zypper ar -cgkn issue-sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_ppc64/ issue-sles:11.4::p=1023
 
   $ sumaxy -A $wd s390x
-  zypper ar -cgkn sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_s390x/ sle-debuginfo:11.3::p=1023
-  zypper ar -cgkn sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_s390x/ sle-debuginfo:11.4::p=1023
-  zypper ar -cgkn sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_s390x/ sles:11.3::p=1023
-  zypper ar -cgkn sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_s390x/ sles:11.4::p=1023
+  zypper ar -cgkn issue-sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_s390x/ issue-sle-debuginfo:11.3::p=1023
+  zypper ar -cgkn issue-sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_s390x/ issue-sle-debuginfo:11.4::p=1023
+  zypper ar -cgkn issue-sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_s390x/ issue-sles:11.3::p=1023
+  zypper ar -cgkn issue-sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_s390x/ issue-sles:11.4::p=1023
 
   $ sumaxy -A $wd x86_64
-  zypper ar -cgkn sle-debuginfo:11.1-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP1-TERADATA_x86_64/ sle-debuginfo:11.1-TERADATA::p=1023
-  zypper ar -cgkn sle-debuginfo:11.3-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3-TERADATA_x86_64/ sle-debuginfo:11.3-TERADATA::p=1023
-  zypper ar -cgkn sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_x86_64/ sle-debuginfo:11.3::p=1023
-  zypper ar -cgkn sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_x86_64/ sle-debuginfo:11.4::p=1023
-  zypper ar -cgkn sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/ sled:11.3::p=1023
-  zypper ar -cgkn sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/ sled:11.4::p=1023
-  zypper ar -cgkn sles:11.1-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP1-TERADATA_x86_64/ sles:11.1-TERADATA::p=1023
-  zypper ar -cgkn sles:11.3-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3-TERADATA_x86_64/ sles:11.3-TERADATA::p=1023
-  zypper ar -cgkn sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_x86_64/ sles:11.3::p=1023
-  zypper ar -cgkn sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_x86_64/ sles:11.4::p=1023
-  zypper ar -cgkn sles-for-vmware:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLES4VMWARE_11-SP3_x86_64/ sles-for-vmware:11.3::p=1023
+  zypper ar -cgkn issue-sle-debuginfo:11.1-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP1-TERADATA_x86_64/ issue-sle-debuginfo:11.1-TERADATA::p=1023
+  zypper ar -cgkn issue-sle-debuginfo:11.3-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3-TERADATA_x86_64/ issue-sle-debuginfo:11.3-TERADATA::p=1023
+  zypper ar -cgkn issue-sle-debuginfo:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_x86_64/ issue-sle-debuginfo:11.3::p=1023
+  zypper ar -cgkn issue-sle-debuginfo:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_x86_64/ issue-sle-debuginfo:11.4::p=1023
+  zypper ar -cgkn issue-sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/ issue-sled:11.3::p=1023
+  zypper ar -cgkn issue-sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/ issue-sled:11.4::p=1023
+  zypper ar -cgkn issue-sles:11.1-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP1-TERADATA_x86_64/ issue-sles:11.1-TERADATA::p=1023
+  zypper ar -cgkn issue-sles:11.3-TERADATA::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3-TERADATA_x86_64/ issue-sles:11.3-TERADATA::p=1023
+  zypper ar -cgkn issue-sles:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_x86_64/ issue-sles:11.3::p=1023
+  zypper ar -cgkn issue-sles:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_x86_64/ issue-sles:11.4::p=1023
+  zypper ar -cgkn issue-sles-for-vmware:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLES4VMWARE_11-SP3_x86_64/ issue-sles-for-vmware:11.3::p=1023
 
 arch + 1 product::
 
   $ sumaxy -A $wd x86_64 sled
-  zypper ar -cgkn sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/ sled:11.3::p=1023
-  zypper ar -cgkn sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/ sled:11.4::p=1023
+  zypper ar -cgkn issue-sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/ issue-sled:11.3::p=1023
+  zypper ar -cgkn issue-sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/ issue-sled:11.4::p=1023
 
   $ sumaxy -A $wd x86_64 sled:11.3 sled:11.4
-  zypper ar -cgkn sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/ sled:11.3::p=1023
-  zypper ar -cgkn sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/ sled:11.4::p=1023
+  zypper ar -cgkn issue-sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/ issue-sled:11.3::p=1023
+  zypper ar -cgkn issue-sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/ issue-sled:11.4::p=1023
 
   $ sumaxy -A $wd x86_64 sled:11.2
 
   $ sumaxy -A $wd x86_64 sled:11.3
-  zypper ar -cgkn sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/ sled:11.3::p=1023
+  zypper ar -cgkn issue-sled:11.3::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/ issue-sled:11.3::p=1023
 
   $ sumaxy -A $wd x86_64 sled:11.4
-  zypper ar -cgkn sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/ sled:11.4::p=1023
+  zypper ar -cgkn issue-sled:11.4::p=1023 http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/ issue-sled:11.4::p=1023

--- a/tests/300-happy-path,removerepo.t
+++ b/tests/300-happy-path,removerepo.t
@@ -11,29 +11,29 @@ setup::
 arch only::
 
   $ sumaxy -R $wd i586
-  zypper rr http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_i586/
-  zypper rr http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_i586/
-  zypper rr http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_i586/
-  zypper rr http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_i586/
-  zypper rr http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_i586/
-  zypper rr http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_i586/
-  zypper rr http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLES4VMWARE_11-SP3_i586/
+  zypper rr issue-http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP3_i586/
+  zypper rr issue-http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DEBUGINFO_11-SP4_i586/
+  zypper rr issue-http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_i586/
+  zypper rr issue-http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_i586/
+  zypper rr issue-http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP3_i586/
+  zypper rr issue-http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-SERVER_11-SP4_i586/
+  zypper rr issue-http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLES4VMWARE_11-SP3_i586/
 
 
 arch + products::
 
   $ sumaxy -R $wd x86_64 sled
-  zypper rr http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/
-  zypper rr http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/
+  zypper rr issue-http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/
+  zypper rr issue-http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/
 
   $ sumaxy -R $wd x86_64 sled:11.3 sled:11.4
-  zypper rr http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/
-  zypper rr http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/
+  zypper rr issue-http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/
+  zypper rr issue-http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/
 
   $ sumaxy -R $wd x86_64 sled:11.2
 
   $ sumaxy -R $wd x86_64 sled:11.3
-  zypper rr http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/
+  zypper rr issue-http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP3_x86_64/
 
   $ sumaxy -R $wd x86_64 sled:11.4
-  zypper rr http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/
+  zypper rr issue-http://dl.example.org/ibs/SUSE:/Maintenance:/1023/SUSE_Updates_SLE-DESKTOP_11-SP4_x86_64/

--- a/tests/400-noarch.t
+++ b/tests/400-noarch.t
@@ -11,10 +11,10 @@ setup::
 test::
 
   $ sumaxy $wd x86_64
-  sles:12.1::p=2087 http://dl.example.org/ibs/SUSE:/Maintenance:/2087/SUSE_Updates_SLE-SERVER_12-SP1_x86_64/
+  issue-sles:12.1::p=2087 http://dl.example.org/ibs/SUSE:/Maintenance:/2087/SUSE_Updates_SLE-SERVER_12-SP1_x86_64/
 
   $ sumaxy $wd s390x
-  sles:12.1::p=2087 http://dl.example.org/ibs/SUSE:/Maintenance:/2087/SUSE_Updates_SLE-SERVER_12-SP1_s390x/
+  issue-sles:12.1::p=2087 http://dl.example.org/ibs/SUSE:/Maintenance:/2087/SUSE_Updates_SLE-SERVER_12-SP1_s390x/
 
   $ sumaxy $wd s390x sles:12.1
-  sles:12.1::p=2087 http://dl.example.org/ibs/SUSE:/Maintenance:/2087/SUSE_Updates_SLE-SERVER_12-SP1_s390x/
+  issue-sles:12.1::p=2087 http://dl.example.org/ibs/SUSE:/Maintenance:/2087/SUSE_Updates_SLE-SERVER_12-SP1_s390x/

--- a/tests/800-cloud.t
+++ b/tests/800-cloud.t
@@ -16,13 +16,13 @@ cloud 5::
   $ wd=$FIXTURES/SUSE:Maintenance:2233:104257
 
   $ sumaxy $wd x86_64
-  suse-cloud:5::p=2233 http://dl.example.org/ibs/SUSE:/Maintenance:/2233/SUSE_Updates_SUSE-CLOUD_5_x86_64/
+  issue-suse-cloud:5::p=2233 http://dl.example.org/ibs/SUSE:/Maintenance:/2233/SUSE_Updates_SUSE-CLOUD_5_x86_64/
 
   $ sumaxy $wd x86_64 suse-cloud:5
-  suse-cloud:5::p=2233 http://dl.example.org/ibs/SUSE:/Maintenance:/2233/SUSE_Updates_SUSE-CLOUD_5_x86_64/
+  issue-suse-cloud:5::p=2233 http://dl.example.org/ibs/SUSE:/Maintenance:/2233/SUSE_Updates_SUSE-CLOUD_5_x86_64/
 
   $ sumaxy $wd x86_64 suse-cloud
-  suse-cloud:5::p=2233 http://dl.example.org/ibs/SUSE:/Maintenance:/2233/SUSE_Updates_SUSE-CLOUD_5_x86_64/
+  issue-suse-cloud:5::p=2233 http://dl.example.org/ibs/SUSE:/Maintenance:/2233/SUSE_Updates_SUSE-CLOUD_5_x86_64/
 
   $ sumaxy $wd x86_64 suse-openstack-cloud:5
 
@@ -33,15 +33,15 @@ cloud 6::
   $ wd=$FIXTURES/SUSE:Maintenance:2218:103606
 
   $ sumaxy $wd x86_64
-  ses:2.1::p=2218 http://dl.example.org/ibs/SUSE:/Maintenance:/2218/SUSE_Updates_Storage_2.1_x86_64/
-  suse-openstack-cloud:6::p=2218 http://dl.example.org/ibs/SUSE:/Maintenance:/2218/SUSE_Updates_OpenStack-Cloud_6_x86_64/
+  issue-ses:2.1::p=2218 http://dl.example.org/ibs/SUSE:/Maintenance:/2218/SUSE_Updates_Storage_2.1_x86_64/
+  issue-suse-openstack-cloud:6::p=2218 http://dl.example.org/ibs/SUSE:/Maintenance:/2218/SUSE_Updates_OpenStack-Cloud_6_x86_64/
 
   $ sumaxy $wd x86_64 suse-cloud:6
 
   $ sumaxy $wd x86_64 suse-cloud
 
   $ sumaxy $wd x86_64 suse-openstack-cloud:6
-  suse-openstack-cloud:6::p=2218 http://dl.example.org/ibs/SUSE:/Maintenance:/2218/SUSE_Updates_OpenStack-Cloud_6_x86_64/
+  issue-suse-openstack-cloud:6::p=2218 http://dl.example.org/ibs/SUSE:/Maintenance:/2218/SUSE_Updates_OpenStack-Cloud_6_x86_64/
 
   $ sumaxy $wd x86_64 suse-openstack-cloud
-  suse-openstack-cloud:6::p=2218 http://dl.example.org/ibs/SUSE:/Maintenance:/2218/SUSE_Updates_OpenStack-Cloud_6_x86_64/
+  issue-suse-openstack-cloud:6::p=2218 http://dl.example.org/ibs/SUSE:/Maintenance:/2218/SUSE_Updates_OpenStack-Cloud_6_x86_64/

--- a/tests/810-ses.t
+++ b/tests/810-ses.t
@@ -9,11 +9,11 @@ setup::
 test::
 
   $ sumaxy $wd x86_64 ses
-  ses:1.0::p=1847 http://dl.example.org/ibs/SUSE:/Maintenance:/1847/SUSE_Updates_Storage_1.0_x86_64/
-  ses:2::p=1847 http://dl.example.org/ibs/SUSE:/Maintenance:/1847/SUSE_Updates_Storage_2_x86_64/
+  issue-ses:1.0::p=1847 http://dl.example.org/ibs/SUSE:/Maintenance:/1847/SUSE_Updates_Storage_1.0_x86_64/
+  issue-ses:2::p=1847 http://dl.example.org/ibs/SUSE:/Maintenance:/1847/SUSE_Updates_Storage_2_x86_64/
 
   $ sumaxy $wd x86_64 ses:1
-  ses:1.0::p=1847 http://dl.example.org/ibs/SUSE:/Maintenance:/1847/SUSE_Updates_Storage_1.0_x86_64/
+  issue-ses:1.0::p=1847 http://dl.example.org/ibs/SUSE:/Maintenance:/1847/SUSE_Updates_Storage_1.0_x86_64/
 
   $ sumaxy $wd x86_64 ses:2
-  ses:2::p=1847 http://dl.example.org/ibs/SUSE:/Maintenance:/1847/SUSE_Updates_Storage_2_x86_64/
+  issue-ses:2::p=1847 http://dl.example.org/ibs/SUSE:/Maintenance:/1847/SUSE_Updates_Storage_2_x86_64/

--- a/tests/820-ltss.t
+++ b/tests/820-ltss.t
@@ -10,8 +10,8 @@ setup::
 test::
 
   $ sumaxy $wd x86_64
-  sles:11.3-LTSS::p=2268 http://dl.example.org/ibs/SUSE:/Maintenance:/2268/SUSE_Updates_SLE-SERVER_11-SP3-LTSS_x86_64/
-  sles:11.3-TERADATA::p=2268 http://dl.example.org/ibs/SUSE:/Maintenance:/2268/SUSE_Updates_SLE-SERVER_11-SP3-TERADATA_x86_64/
+  issue-sles:11.3-LTSS::p=2268 http://dl.example.org/ibs/SUSE:/Maintenance:/2268/SUSE_Updates_SLE-SERVER_11-SP3-LTSS_x86_64/
+  issue-sles:11.3-TERADATA::p=2268 http://dl.example.org/ibs/SUSE:/Maintenance:/2268/SUSE_Updates_SLE-SERVER_11-SP3-TERADATA_x86_64/
 
   $ sumaxy $wd x86_64 sles:11.3
-  sles:11.3-LTSS::p=2268 http://dl.example.org/ibs/SUSE:/Maintenance:/2268/SUSE_Updates_SLE-SERVER_11-SP3-LTSS_x86_64/
+  issue-sles:11.3-LTSS::p=2268 http://dl.example.org/ibs/SUSE:/Maintenance:/2268/SUSE_Updates_SLE-SERVER_11-SP3-LTSS_x86_64/

--- a/tests/830-security.t
+++ b/tests/830-security.t
@@ -10,23 +10,23 @@ setup::
 test::
 
   $ sumaxy $wd x86_64
-  sle-debuginfo:11.3-TERADATA::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-DEBUGINFO_11-SP3-TERADATA_x86_64/
-  sle-debuginfo:11.3::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-DEBUGINFO_11-SP3_x86_64/
-  sle-debuginfo:11.4::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-DEBUGINFO_11-SP4_x86_64/
-  sle-sdk:11.4::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SDK_11-SP4_x86_64/
-  sles:11-SECURITY::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SERVER_11-SECURITY_x86_64/
-  sles:11.1-TERADATA::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SERVER_11-SP1-TERADATA_x86_64/
-  sles:11.3-LTSS::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SERVER_11-SP3-LTSS_x86_64/
-  sles:11.3-TERADATA::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SERVER_11-SP3-TERADATA_x86_64/
-  sles:11.4::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SERVER_11-SP4_x86_64/
-  suse-cloud:5::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SUSE-CLOUD_5_x86_64/
-  suse-manager-proxy:2.1::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SUSE-MANAGER-PROXY_2.1_x86_64/
-  suse-manager-server:2.1::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SUSE-MANAGER_2.1_x86_64/
+  issue-sle-debuginfo:11.3-TERADATA::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-DEBUGINFO_11-SP3-TERADATA_x86_64/
+  issue-sle-debuginfo:11.3::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-DEBUGINFO_11-SP3_x86_64/
+  issue-sle-debuginfo:11.4::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-DEBUGINFO_11-SP4_x86_64/
+  issue-sle-sdk:11.4::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SDK_11-SP4_x86_64/
+  issue-sles:11-SECURITY::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SERVER_11-SECURITY_x86_64/
+  issue-sles:11.1-TERADATA::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SERVER_11-SP1-TERADATA_x86_64/
+  issue-sles:11.3-LTSS::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SERVER_11-SP3-LTSS_x86_64/
+  issue-sles:11.3-TERADATA::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SERVER_11-SP3-TERADATA_x86_64/
+  issue-sles:11.4::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SERVER_11-SP4_x86_64/
+  issue-suse-cloud:5::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SUSE-CLOUD_5_x86_64/
+  issue-suse-manager-proxy:2.1::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SUSE-MANAGER-PROXY_2.1_x86_64/
+  issue-suse-manager-server:2.1::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SUSE-MANAGER_2.1_x86_64/
 
   $ sumaxy $wd x86_64 sles:11.3
-  sles:11-SECURITY::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SERVER_11-SECURITY_x86_64/
-  sles:11.3-LTSS::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SERVER_11-SP3-LTSS_x86_64/
+  issue-sles:11-SECURITY::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SERVER_11-SECURITY_x86_64/
+  issue-sles:11.3-LTSS::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SERVER_11-SP3-LTSS_x86_64/
 
   $ sumaxy $wd x86_64 sles:11.4
-  sles:11-SECURITY::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SERVER_11-SECURITY_x86_64/
-  sles:11.4::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SERVER_11-SP4_x86_64/
+  issue-sles:11-SECURITY::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SERVER_11-SECURITY_x86_64/
+  issue-sles:11.4::p=2455 http://dl.example.org/ibs/SUSE:/Maintenance:/2455/SUSE_Updates_SLE-SERVER_11-SP4_x86_64/


### PR DESCRIPTION
This change simplifies recognize of isseu repos from standard product
repos. Plus fixes repose reset for refhost with added issue repositories

Fixes https://github.com/openSUSE/repose/issues/81